### PR TITLE
Add row index to view

### DIFF
--- a/leaderboard-page/client/src/App.vue
+++ b/leaderboard-page/client/src/App.vue
@@ -23,6 +23,9 @@
                 <template slot="items"
                           slot-scope="props">
                   <td class="text-xs-center">
+                    {{ props.index + 1}}
+                  </td>
+                  <td class="text-xs-center">
                     <v-avatar slot="activator"
                               size="36px">
                       <img :src="`https://avatars.githubusercontent.com/${props.item.UserLogin}`"
@@ -56,19 +59,28 @@ export default {
       headers: [
         {
           text: "",
-          value: ""
+          value: "",
+          align: "center",
+        },
+        {
+          text: "",
+          value: "",
+          sortable: false
         },
         {
           text: "Login",
-          value: "UserLogin"
+          value: "UserLogin",
+          align: "ceenter"
         },
         {
           text: "issue Comments",
-          value: "IssueComments"
+          value: "IssueComments",
+          align: "right"
         },
         {
           text: "issues opened",
-          value: "IssuesCreated"
+          value: "IssuesCreated",
+          align: "right"
         }
       ],
       items: []


### PR DESCRIPTION
Added row index to quickly see at what number each user is
Also adjusted the alignment to better match up with the
results being displayed. Most obvious on larger screens

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

Before:
![Screenshot from 2019-06-03 19-01-11](https://user-images.githubusercontent.com/12687192/58842108-512e8200-8632-11e9-952d-1f69938d300f.png)

After:
![Screenshot from 2019-06-03 19-01-05](https://user-images.githubusercontent.com/12687192/58842112-568bcc80-8632-11e9-901a-55617240d6b0.png)
